### PR TITLE
Fixing icon and tooltip for edit not displaying for ecosystem popup

### DIFF
--- a/app/assets/javascripts/workflows.js
+++ b/app/assets/javascripts/workflows.js
@@ -168,12 +168,12 @@ function populate_html_from_latlng( lat, lng ) {
         $('div.well:not(.inactive_site)').find('.native_biomes').find('.biome_list').append(
           '<div class="biome_match checkbox">' +
             '<label class="biome-match"><input type="checkbox">' + k.replace(/_/g," ") + '</input></label>' +
-            '<a class="edit_icon_link" data-toggle="lightbox" href="#ecosystem_popup">' +
-              '<i class="icon-search icon-list-alt inline-block edit_icon" rel="tooltip" title="edit"></i>' +
+            '<a class="edit_icon_link action-link" data-toggle="lightbox" href="#ecosystem_popup">' +
+              '<i class="glyphicon glyphicon-list-alt" rel="tooltip" title="Edit"></i>' +
             '</a>' +
-            '<a class="biome_pdf_link" href="' +
+            '<a class="biome_pdf_link action-link"href="' +
             '/assets/' + v.code + '.pdf' + //pdf file name
-            '" download><img src="/assets/pdf_24x24.png" width="16"></a>' +
+            '" download><img class="download-pdf-icon" src="/assets/pdf_24x24.png"></a>' +
           '</div>'
         ).parent().css("height", "auto");
         // Could add delegate option here to show / hide the EDIT icon on checking the checkbox

--- a/app/assets/stylesheets/custom.css.scss
+++ b/app/assets/stylesheets/custom.css.scss
@@ -1,3 +1,4 @@
+@import "bootstrap-sprockets";
 @import "bootstrap";
 
 /* mixins, variables, etc. */

--- a/app/assets/stylesheets/workflows.css.scss
+++ b/app/assets/stylesheets/workflows.css.scss
@@ -26,7 +26,7 @@ div[id|='biome_instance'] {
   width: 140px;
 }
 
-#map_canvas { 
+#map_canvas {
   width: 1025px;
   height: 600px;
 }
@@ -154,7 +154,6 @@ div[id|='biome_instance'] {
   div[class*='_biomes'] {
     vertical-align: top;
     width: 210px;
-  
   }
 }
 
@@ -170,15 +169,13 @@ div[id|='biome_instance'] {
     thead {
       display:block;
       height: 30px;
-      
     }
     /* allows the tables to scroll */
     tbody {
-      height: 200px; 
-      overflow:auto; 
+      height: 200px;
+      overflow:auto;
       display:block;
     }
-    
   }
 }
 
@@ -263,3 +260,12 @@ div[class*='_biomes'] {
   padding: 7px;
 }
 
+.action-link {
+  padding-left: 2px;
+  padding-right: 2px;
+}
+
+.download-pdf-icon {
+  width: 20px;
+  height: 20px;
+}

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -5,12 +5,12 @@
     GHGVcalc
     </title>
     <%= stylesheet_link_tag "application", media: "all" %>
-    
+
     <!-- Speed: use googles jQuery ... bc if they use google they've already got the lib cached-->
     <script src="//ajax.googleapis.com/ajax/libs/jquery/1.8.2/jquery.min.js"></script>
     <%= javascript_include_tag "application" %>
     <%= csrf_meta_tags %>
-    
+
     <!--[if lt IE 9]>
     <script src="http://html5shim.googlecode.com/svn/trunk/html5.js"></script>
     <![endif]-->


### PR DESCRIPTION
References #9.

Updated:
- Use bootstrap glyphicon classes
- Updated the jquery tooltip usage
- Extracted some inline styles to classes w/ css