### PR TITLE
only bind R service to loopback

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,4 +6,4 @@ services:
     volumes:
       - ../ghgvcD:/home/ghgvcr/data
     ports:
-      - "6311:6311"
+      - "127.0.0.1:6311:6311"


### PR DESCRIPTION
Correcting my mistake! This will set things so that the forwarded port for the Rserve service is only bound and listening on the loopback interface, not _all_ interfaces. Don't want to provide the coffee shop unlimited R!